### PR TITLE
Context base path to assume no protocol

### DIFF
--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -190,7 +190,7 @@ def compute_context(resource_path, request, root_resource):
         base_path = full_path[:-len(resource_path)]
 
     ctx = APIContext(
-        base_uri=re.sub('https?:', '', base_path),
+        base_uri=re.sub('https?:', '', request.build_absolute_uri(base_path)),
         root_resource=root_resource,
         formatter=JSONFormatter(),
         request=request

--- a/savory_pie/django/views.py
+++ b/savory_pie/django/views.py
@@ -190,7 +190,7 @@ def compute_context(resource_path, request, root_resource):
         base_path = full_path[:-len(resource_path)]
 
     ctx = APIContext(
-        base_uri=request.build_absolute_uri(base_path),
+        base_uri=re.sub('https?:', '', base_path),
         root_resource=root_resource,
         formatter=JSONFormatter(),
         request=request


### PR DESCRIPTION
What
==
Forcing a protocol onto resource paths causes issues when terminating SSL downstream. Just return protocol agnostic resource paths so that we can use https everywhere.