### PR TITLE
Allow comparison with protocol-relative URIs.

### DIFF
--- a/savory_pie/context.py
+++ b/savory_pie/context.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 
 
 class APIContext(object):
@@ -31,6 +32,10 @@ class APIContext(object):
         Resolves the resource that corresponds to the current URI,
         but only within the same resource tree.
         """
+        # Allows comparison with protocol-relative resource URIs
+        if self.base_uri.startswith('//') and not uri.startswith('//'):
+            uri = re.sub('https?:', '', uri)
+
         if not uri.startswith(self.base_uri):
             return None
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '0.2.1'
+version = '0.2.2'
 
 setup(
     name='savory-pie',


### PR DESCRIPTION
**Problem**: After making most URIs protocol-relative, `resolve_resource_uri` started failing when comparing against those URIs.

**Findings**: When a new resource is created, a Location is returned in the header. This uses `HttpRequest.build_resource_uri` ([see here](https://github.com/django/django/blob/268a646353c6fa9e5fc3730e13b386ddabb018ef/django/http/request.py#L172-L175)) which forces a protocol on the URI. Because of this, we always end up parsing a URI with a protocol.

**Fix**: When comparing URIs, we normalize them to be protocol-relative if the `base_uri` already is.